### PR TITLE
updating KNC telescope and instrument names

### DIFF
--- a/instruments.yaml
+++ b/instruments.yaml
@@ -80,7 +80,7 @@
   =id: iT11-PL11002M_Instrument
 
 #groupeKNC
-- name: iT21-PL6303E
+- name: iT21_83-PL6303E
   type: imager
   band: Optical
   telescope_id: =iT21

--- a/instruments.yaml
+++ b/instruments.yaml
@@ -46,7 +46,7 @@
   =id: MMATest_Instrument
 
 #groupeKNC
-- name: iT8-Microline16803
+- name: iT8_15-Microline16803
   type: imager
   band: Optical
   telescope_id: =iT8
@@ -55,7 +55,7 @@
   =id: iT8-Microline16803_Instrument
 
 #groupeKNC
-- name: iT32-Proline16803
+- name: iT32_85-Proline16803
   type: imager
   band: Optical
   telescope_id: =iT32
@@ -66,7 +66,7 @@
   =id: iT32-Proline16803_Instrument
 
 #groupeKNC
-- name: iT11-PL11002M
+- name: iT11_53-PL11002M
   type: imager
   band: Optical
   telescope_id: =iT11
@@ -93,7 +93,7 @@
   - ps1::open
   =id: iT21-PL6303E_Instrument
 #groupeKNC
-- name: iT31-PL09000
+- name: iT31_84-PL09000
   type: imager
   band: Optical
   telescope_id: =iT31
@@ -104,7 +104,7 @@
   - ps1::open
   =id: iT31-PL09000_Instrument
 #groupeKNC
-- name: iT30-PL6303E
+- name: iT30_54-PL6303E
   type: imager
   band: Optical
   telescope_id: =iT30
@@ -117,7 +117,7 @@
   - ps1::open
   =id: iT30-PL6303E_Instrument
 #groupeKNC
-- name: iT17-PL4710
+- name: iT17_69-PL4710
   type: imager
   band: Optical
   telescope_id: =iT17

--- a/telescopes.yaml
+++ b/telescopes.yaml
@@ -226,7 +226,7 @@
   weather_link: null
   =id: SNOVA
 
-- name: iT8
+- name: iT8_15
   nickname: iT8
   lat: -31.2719
   lon: 149.0617
@@ -238,7 +238,7 @@
   weather_link: null
   =id: iT8
 
-- name: iT11
+- name: iT11_53
   nickname: iT11
   lat: 32.9
   lon: -105.5
@@ -250,7 +250,7 @@
   weather_link: null
   =id: iT11
 
-- name: iT30
+- name: iT30_54
   nickname: iT30
   lat: -31.2733
   lon: 149.0644
@@ -262,7 +262,7 @@
   weather_link: null
   =id: iT30
 
-- name: iT17
+- name: iT17_69
   nickname: iT17
   lat: -31.273
   lon: 149.0644
@@ -286,7 +286,7 @@
   weather_link: null
   =id: iT21
 
-- name: iT31
+- name: iT31_84
   nickname: iT31
   lat: -31.273
   lon: 149.0644
@@ -298,7 +298,7 @@
   weather_link: null
   =id: iT31
 
-- name: iT32
+- name: iT32_85
   nickname: iT32
   lat: -31.273
   lon: 149.0644

--- a/telescopes.yaml
+++ b/telescopes.yaml
@@ -274,7 +274,7 @@
   weather_link: null
   =id: iT17
 
-- name: iT21
+- name: iT21_83
   nickname: iT21
   lat: 32.9
   lon: -105.5


### PR DESCRIPTION
just modified the telescope and instrument names by adding the knc_tel_id. the skyportal telescope and instrument id and nickname are not modified